### PR TITLE
Submodule mt database

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "machine-teaching-db"]
+	path = machine-teaching-db
+	url = git@github.com:MachineTeachingEdu/machine-teaching-db.git

--- a/Makefile
+++ b/Makefile
@@ -7,19 +7,15 @@ IMAGE_DESTINATION = gcr.io/$(GCP_PROJECT_ID)/$(GCP_APPLICATION_NAME)
 VERSION=$(shell (git rev-parse HEAD))
 
 up:
+	mkdir -p ./machine-teaching-db/data
+	sh ./machine-teaching-db/dump.sh
 	docker-compose up
 
 run:
 	@echo "Version ID: $(VERSION)";
 	docker build --tag $(IMAGE_DESTINATION):$(VERSION) .
 	docker run  --env-file .env -p 8080:8080 $(IMAGE_DESTINATION):$(VERSION)
-	@echo "Image submitted to destination repository :)"
 		
-deploy:
-	/home/gxara/Downloads/heroku/bin/heroku container:push web --app machine-teaching-ufrj
-	/home/gxara/Downloads/heroku/bin/heroku container:release web --app machine-teaching-ufrj
-
-
 deploy-gcp:
 	@echo "Version ID: $(VERSION)";
 	docker build --tag $(IMAGE_DESTINATION):$(VERSION) .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,9 @@ version: "3.7"
 services:
   machine_teaching_db:
     image: postgres:9.6
-    environment:
-      - POSTGRES_USER=dev_user
-      - POSTGRES_PASSWORD=secure_password
-      - POSTGRES_DB=machine_teaching_db
+    env_file: .env
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - machine-teaching-db/data/dump.sql:/docker-entrypoint-initdb.d/create_tables.sql
     ports:
       - 5432:5432
   web:
@@ -30,8 +27,3 @@ services:
       - APP_SECRET_KEY=SUPER_SECRET_KEY_1234
     depends_on:
       - machine_teaching_db
-
-volumes:
-  db-data:
-    driver:
-      local


### PR DESCRIPTION
Utiliza a estratégia de `submodules` para conectar em um só docker-compose a aplicação deste repositório com o banco criado pelo repositório maching-teaching-db

Link útil: https://gist.github.com/gitaarik/8735255

Como rodar: `make up`